### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mariusbreivik/conventional-commits-suggester/security/code-scanning/2](https://github.com/mariusbreivik/conventional-commits-suggester/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow file to limit the permissions of the `GITHUB_TOKEN`. Since the workflow involves checking out code and installing dependencies, the job needs read-only access to repository contents. The least privilege permissions required for this workflow are `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
