### PR TITLE
test: improve suggestConventionalMessage coverage with more edge cases

### DIFF
--- a/tests/suggestConventionalMessage.test.js
+++ b/tests/suggestConventionalMessage.test.js
@@ -15,4 +15,30 @@ describe("suggestConventionalMessage", () => {
     it("handles single word message", () => {
         expect((0, suggestConventionalMessage_1.suggestConventionalMessage)("refactor")).toBe("fix: refactor");
     });
+    it("returns 'fix:' for empty or whitespace-only message", () => {
+        expect((0, suggestConventionalMessage_1.suggestConventionalMessage)("   ")).toBe("fix:");
+    });
+    it("suggests for type(scope): with no subject", () => {
+        expect((0, suggestConventionalMessage_1.suggestConventionalMessage)("fix(core): ")).toBe("fix(core): ");
+    });
+    it("suggests for unknown type as scope", () => {
+        expect((0, suggestConventionalMessage_1.suggestConventionalMessage)("improve(core): performance")).toBe("fix(improve): performance");
+    });
+    it("suggests for invalid scope", () => {
+        const result = (0, suggestConventionalMessage_1.suggestConventionalMessage)("fix(bad!scope): bug");
+        expect(result).toMatch(/not allowed/);
+        expect(result).toMatch(/allowed scopes/);
+    });
+    it("suggests for message with only type", () => {
+        expect((0, suggestConventionalMessage_1.suggestConventionalMessage)("fix:")).toBe("fix: fix:");
+    });
+    it("suggests for message with subject starting with space", () => {
+        expect((0, suggestConventionalMessage_1.suggestConventionalMessage)("fix(core):  bad subject")).toBe("fix(core):  bad subject");
+    });
+    it("suggests for message with emoji", () => {
+        expect((0, suggestConventionalMessage_1.suggestConventionalMessage)("fix: 🐛 bug squashed")).toBe("fix: 🐛 bug squashed");
+    });
+    it("suggests for message with dash scope", () => {
+        expect((0, suggestConventionalMessage_1.suggestConventionalMessage)("fix(-): dash scope")).toBe("fix(-): dash scope");
+    });
 });

--- a/tests/suggestConventionalMessage.test.ts
+++ b/tests/suggestConventionalMessage.test.ts
@@ -26,4 +26,36 @@ describe("suggestConventionalMessage", () => {
         suggestConventionalMessage("refactor", allowedTypes, allowedScopes)
     ).toBe("fix: refactor");
   });
+  it("returns 'fix:' for empty or whitespace-only message", () => {
+    expect(suggestConventionalMessage("   ", allowedTypes, allowedScopes)).toBe("fix:");
+  });
+  it("suggests for type(scope): with no subject", () => {
+    expect(suggestConventionalMessage("fix(core): ", allowedTypes, allowedScopes)).toBe("fix(core): ");
+  });
+  it("suggests for unknown type as scope", () => {
+    expect(suggestConventionalMessage("improve(core): performance", allowedTypes, allowedScopes)).toBe("fix(improve): performance");
+  });
+  it("suggests for invalid scope", () => {
+    const result = suggestConventionalMessage("fix(bad!scope): bug", allowedTypes, allowedScopes);
+    expect(result).toMatch(/not allowed/);
+    expect(result).toMatch(/allowed scopes/);
+  });
+  it("suggests for message with only type", () => {
+    expect(suggestConventionalMessage("fix:", allowedTypes, allowedScopes)).toBe("fix: fix:");
+  });
+  it("suggests for message with subject starting with space", () => {
+    expect(suggestConventionalMessage("fix(core):  bad subject", allowedTypes, allowedScopes)).toBe("fix(core):  bad subject");
+  });
+  it("suggests for message with emoji", () => {
+    expect(suggestConventionalMessage("fix: 🐛 bug squashed", allowedTypes, allowedScopes)).toBe("fix: 🐛 bug squashed");
+  });
+  it("suggests for message with dash scope", () => {
+    expect(suggestConventionalMessage("fix(-): dash scope", allowedTypes, allowedScopes)).toBe("fix(-): dash scope");
+  });
+  it("suggests for message with unknown scope and custom allowedScopes", () => {
+    const customScopes = ["foo", "bar"];
+    const result = suggestConventionalMessage("fix(baz): test", allowedTypes, customScopes);
+    expect(result).toMatch(/not allowed/);
+    expect(result).toMatch(/foo/);
+  });
 });


### PR DESCRIPTION
This PR adds comprehensive new tests for the suggestConventionalMessage function, covering more edge cases and error scenarios. This improves the reliability and maintainability of the commit suggestion logic.

- Adds tests for empty messages, invalid scopes, emoji, dash scopes, and custom allowedScopes
- Ensures all branches of the suggestion logic are exercised

All new tests pass locally.

Closes #improve-test-coverage